### PR TITLE
Update JSON gem dependency to v2.0

### DIFF
--- a/passivetotal.gemspec
+++ b/passivetotal.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "json", "~> 1.8"
+  spec.add_runtime_dependency "json", "~> 2.0"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
JSON gem dependency is fairly outdated. No particular reason I could see to lock it into a version >= 1.8 and to keep it below v2.0. If there is a reason to keep the 1.8 dependency, we can change the gemspec to include that, but for now I just bumped it up to 2.0. 

Reasoning behind this update is to avoid conflicts with newer gems that set their dependency to ~> 2.0, which doesn't allow use of 1.8. 