### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.2.1
-before_install: gem install bundler -v 1.10.5
+  - 2.5
+before_install: gem install bundler -v 1.17.1


### PR DESCRIPTION
Ruby 2.2 has ended.  So it’s good to use the latest version.
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

And also bundler v1.10 is outdated.