### PR TITLE
Error handling with HTTP status code

### DIFF
--- a/lib/passivetotal/api.rb
+++ b/lib/passivetotal/api.rb
@@ -550,16 +550,13 @@ module PassiveTotal # :nodoc:
         delta
       )
 
-      if data['error']
-        message = data['error']['message']
-        case message
-        when "API key provided does not match any user."
-          raise InvalidAPIKeyError.new(obj)
-        when "Quota has been exceeded!"
-          raise ExceededQuotaError.new(obj)
-        else
-          raise APIUsageError.new(obj)
-        end
+      case response.code
+      when "401"
+        raise InvalidAPIKeyError.new(obj)
+      when "429"
+        raise ExceededQuotaError.new(obj)
+      else
+        raise APIUsageError.new(obj)
       end
 
       return obj


### PR DESCRIPTION
We just found that how api.rb handling response might be out dated.

currently RiskIQ API send error on it's status code instead of error message.

for example:

```bash
curl -u "test@test.com":"1234567812345678123456781234567812345678123456781234567812345678" 'https://api.riskiq.net/pt/v2/dns/passive?query=passivetotal.org' -v

< HTTP/2 401 
< server: nginx/1.19.2
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< x-frame-options: DENY
< strict-transport-security: max-age=15724800; includeSubDomains
< 
{
    "message": "invalid credentials"
* Connection #0 to host api.riskiq.net left intact
}* Closing connection 0

```

`401 unauthorized` for invalid user and  `429 Too Many Requests` if your monthly quota ran out. 